### PR TITLE
Fix rxjs import

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nicky-lenaers/ngx-scroll-to-demo",
   "description": "Demo Application for @nicky-lenaers/ngx-scroll-to package.",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "license": "MIT",
   "scripts": {
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s -r 0",

--- a/projects/ngx-scroll-to/package.json
+++ b/projects/ngx-scroll-to/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nicky-lenaers/ngx-scroll-to",
   "description": "A simple Angular 4+ plugin enabling you to smooth scroll to any element on your page and enhance scroll-based features in your app.",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "scripts": {
     "build": "ng build"
   },

--- a/projects/ngx-scroll-to/src/lib/scroll-to-animation.ts
+++ b/projects/ngx-scroll-to/src/lib/scroll-to-animation.ts
@@ -1,4 +1,4 @@
-import { Observable, ReplaySubject } from 'rxjs/index';
+import { Observable, ReplaySubject } from 'rxjs';
 
 import { EASING } from './scroll-to-helpers';
 import {

--- a/projects/ngx-scroll-to/src/lib/scroll-to.service.ts
+++ b/projects/ngx-scroll-to/src/lib/scroll-to.service.ts
@@ -18,7 +18,7 @@ import {
   DEFAULTS,
   isNativeElement
 } from './scroll-to-helpers';
-import { Observable, ReplaySubject, throwError } from 'rxjs/index';
+import { Observable, ReplaySubject, throwError } from 'rxjs';
 
 /**
  * The Scroll To Service handles starting, interrupting


### PR DESCRIPTION
Fix #110 

Replace all `rjx/index` imports to prevent `rxjs` to be imported entirely. 