### PR TITLE
chore(Package): Don't enforce newer node engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nicky-lenaers/ngx-scroll-to-demo",
   "description": "Demo Application for @nicky-lenaers/ngx-scroll-to package.",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "license": "MIT",
   "scripts": {
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s -r 0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nicky-lenaers/ngx-scroll-to-demo",
   "description": "Demo Application for @nicky-lenaers/ngx-scroll-to package.",
-  "version": "2.0.2",
+  "version": "2.0.1",
   "license": "MIT",
   "scripts": {
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s -r 0",

--- a/projects/ngx-scroll-to/package.json
+++ b/projects/ngx-scroll-to/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nicky-lenaers/ngx-scroll-to",
   "description": "A simple Angular 4+ plugin enabling you to smooth scroll to any element on your page and enhance scroll-based features in your app.",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "scripts": {
     "build": "ng build"
   },
@@ -48,7 +48,7 @@
     "url": "https://github.com/nicky-lenaers/ngx-scroll-to/issues"
   },
   "engines": {
-    "node": ">=10.0.0",
+    "node": ">=8.0.0",
     "npm": ">=6.0.0"
   },
   "peerDependencies": {

--- a/projects/ngx-scroll-to/package.json
+++ b/projects/ngx-scroll-to/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nicky-lenaers/ngx-scroll-to",
   "description": "A simple Angular 4+ plugin enabling you to smooth scroll to any element on your page and enhance scroll-based features in your app.",
-  "version": "2.0.2",
+  "version": "2.0.1",
   "scripts": {
     "build": "ng build"
   },

--- a/tslint.json
+++ b/tslint.json
@@ -16,10 +16,6 @@
     ],
     "eofline": true,
     "forin": true,
-    "import-blacklist": [
-      true,
-      "rxjs"
-    ],
     "import-spacing": true,
     "indent": [
       true,


### PR DESCRIPTION
There is no need to enforce engine >=10.0.0 given this is not a node library.

Without this, if downstream projects are on node < 10, they will get the following error when trying to install. 

```
[2/4] 🚚  Fetching packages...
error @nicky-lenaers/ngx-scroll-to@2.0.0: The engine "node" is incompatible with this module. Expected version ">=10.0.0". Got "8.9.4"
error Found incompatible module
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```

There is no workaround for this unfortunately
